### PR TITLE
added capability to copy inspire-hep ID to clipboard

### DIFF
--- a/src/modules/zinspire.ts
+++ b/src/modules/zinspire.ts
@@ -78,34 +78,35 @@ export class ZInsMenu {
             commandListener: (_ev) => {
               _globalThis.inspire.updateSelectedItems("citations")
             }
-          },
-          {
-            tag: "menuseparator"
-          },
-          {
-            tag: "menuitem",
-            label: "Copy INSPIRE-HEP bibtex",
-            commandListener: (_ev) => {
-              const items = ZoteroPane.getSelectedItems();
-              if (items.length === 1) {
-                _globalThis.inspire.copyInspireBibtex(items[0]);
-              } else {
-                const progressWindow = new ztoolkit.ProgressWindow(config.addonName, {
-                  closeOnClick: true,
-                });
-                progressWindow.changeHeadline("Error");
-                progressWindow.createLine({
-                  icon: "chrome://zotero/skin/cross.png",
-                  text: "Please select exactly one item"
-                });
-                progressWindow.show();
-                progressWindow.startCloseTimer(4000);
-              }
-            }
           }
         ],
         icon: menuIcon,
       },    
+    );
+
+    ztoolkit.Menu.register("item",
+      {
+        tag: "menuitem",
+        label: "Copy Inspire BibTex Information",
+        commandListener: (_ev) => {
+          const items = ZoteroPane.getSelectedItems();
+          if (items.length === 1) {
+            _globalThis.inspire.copyInspireBibtex(items[0]);
+          } else {
+            const progressWindow = new ztoolkit.ProgressWindow(config.addonName, {
+              closeOnClick: true,
+            });
+            progressWindow.changeHeadline("Error");
+            progressWindow.createLine({
+              icon: "chrome://zotero/skin/cross.png",
+              text: "Please select exactly one item"
+            });
+            progressWindow.show();
+            progressWindow.startCloseTimer(4000);
+          }
+        },
+        icon: menuIcon
+      }
     );
   }
 


### PR DESCRIPTION
Hi,

I just did this quickly in my fork, but maybe this would be a useful feature to consider in the future. Sometimes I do not want to use zoteros full bib export capabilities and just get the clean and proper bibtex entry from inspire-hep.

Looking forward to your input!

Cheers,
Florian