### PR TITLE
Fix close and remove button not centered in CitationGraphDialog and apply button background color style in smartUpdate.ts.

### DIFF
--- a/src/modules/inspire/panel/CitationGraphDialog.ts
+++ b/src/modules/inspire/panel/CitationGraphDialog.ts
@@ -639,6 +639,9 @@ export class CitationGraphDialog {
       line-height: 1;
       cursor: pointer;
       user-select: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     `;
     closeBtn.addEventListener("click", () => this.dispose());
     this.closeBtn = closeBtn;
@@ -2919,6 +2922,9 @@ button.zinspire-citation-graph-refresh.zinspire-citation-graph-refresh--loading 
         cursor: pointer;
         user-select: none;
         flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       `;
       removeBtn.addEventListener("click", (e) => {
         e.stopPropagation();

--- a/src/modules/inspire/smartUpdate.ts
+++ b/src/modules/inspire/smartUpdate.ts
@@ -1196,7 +1196,7 @@ export async function showSmartUpdatePreviewDialog(
     applyBtn.style.minWidth = "80px";
     applyBtn.style.border = "none";
     applyBtn.style.borderRadius = "4px";
-    applyBtn.style.backgroundColor = "#0066cc";
+    applyBtn.style.background = "#0066cc";
     applyBtn.style.color = "#fff";
     applyBtn.style.cursor = "pointer";
     applyBtn.style.fontSize = "13px";


### PR DESCRIPTION
Before:
<img width="114" height="81" alt="image" src="https://github.com/user-attachments/assets/4b615143-65eb-4f96-824a-8b88db7c84b1" />

After: 
<img width="125" height="79" alt="image" src="https://github.com/user-attachments/assets/d8848c84-1d9b-405f-8f22-7fa2945636be" />

Before:
<img width="102" height="69" alt="image" src="https://github.com/user-attachments/assets/5017c428-d701-4ad1-9d8c-4da265854d59" />

After: 
<img width="113" height="72" alt="image" src="https://github.com/user-attachments/assets/7185ac8a-d660-4d46-ac94-33959fed3db6" />

Before:
<img width="224" height="98" alt="image" src="https://github.com/user-attachments/assets/d5c59c3d-336b-4056-9f8f-503c36889398" />

After: 
<img width="310" height="128" alt="image" src="https://github.com/user-attachments/assets/c6c44f1e-8d98-4833-bbf8-28953ac70fe3" />
